### PR TITLE
Fix BiLD Metadata in Translation Example

### DIFF
--- a/examples/pytorch/translation/run_translation.py
+++ b/examples/pytorch/translation/run_translation.py
@@ -100,10 +100,10 @@ class ModelArguments:
         },
     )
     large: Optional[str] = field(
-        default=None, metadata={"help": "The name of the dataset to use (via the datasets library)."}
+        default=None, metadata={"help": "The path to the large model used for BiLD."}
     )
     small: Optional[str] = field(
-        default=None, metadata={"help": "The name of the dataset to use (via the datasets library)."}
+        default=None, metadata={"help": "The path to the small model used for BiLD."}
     )
     fallback_threshold: Optional[float] = field(
         default=None,


### PR DESCRIPTION
Updates the metadata for the small and large fields in BiLD's translation example to have the correct description.